### PR TITLE
Create time boxing planner web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# TIme_boxing
+# Time Boxing Planner
+
+A lightweight, single-page planner that helps you organize your day into focused time blocks. Capture your top priorities, clear your mind with a brain dump, and schedule tasks in 30-minute increments — all in one printable page that saves locally in your browser.
+
+## Features
+
+- **Top priorities list** – Keep the day's three most important tasks front and center.
+- **Brain dump space** – Jot down ideas or distractions so you can refocus quickly.
+- **30-minute schedule** – Plan from 5:00 AM through 11:30 PM with flexible text areas.
+- **Local saving** – Data is stored per day using your browser's local storage.
+- **Quick actions** – Clear the current day or print your schedule with one click.
+
+## Getting Started
+
+1. Clone this repository or download the source.
+2. Open `index.html` in your browser.
+   - Optionally, serve the files locally for best results:
+     ```bash
+     python -m http.server 8000
+     ```
+3. Start planning! Switch the date at the top to view or create schedules for different days.
+
+## Notes
+
+- All data is stored in your browser's local storage and never leaves your device.
+- If you clear your browser data or use a private/incognito window, your planner entries may not persist.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Time Boxing Planner</title>
+    <link rel="stylesheet" href="styles.css" />
+  </head>
+  <body>
+    <header class="app-header">
+      <div>
+        <h1>Time Boxing Planner</h1>
+        <p class="tagline">Plan your day in focused blocks.</p>
+      </div>
+      <div class="date-picker">
+        <label for="planner-date">Date</label>
+        <input
+          id="planner-date"
+          type="date"
+          aria-label="Planner date"
+        />
+      </div>
+    </header>
+
+    <noscript>
+      <div class="noscript-warning">
+        This planner uses JavaScript to populate the schedule and save your data.
+        Please enable JavaScript to use all features.
+      </div>
+    </noscript>
+
+    <main class="planner">
+      <div class="column column--left">
+        <section class="card priorities">
+          <h2>Top Priorities</h2>
+          <ol class="priority-list">
+            <li>
+              <textarea
+                rows="2"
+                data-storage-key="priority-1"
+                aria-label="Top priority 1"
+                placeholder="What absolutely needs to get done today?"
+              ></textarea>
+            </li>
+            <li>
+              <textarea
+                rows="2"
+                data-storage-key="priority-2"
+                aria-label="Top priority 2"
+                placeholder="What absolutely needs to get done today?"
+              ></textarea>
+            </li>
+            <li>
+              <textarea
+                rows="2"
+                data-storage-key="priority-3"
+                aria-label="Top priority 3"
+                placeholder="What absolutely needs to get done today?"
+              ></textarea>
+            </li>
+          </ol>
+        </section>
+
+        <section class="card brain-dump">
+          <div class="section-header">
+            <h2>Brain Dump</h2>
+            <p class="helper-text">
+              Capture ideas, notes, and tasks so they don't distract you later.
+            </p>
+          </div>
+          <textarea
+            rows="14"
+            data-storage-key="brain-dump"
+            aria-label="Brain dump"
+            placeholder="Write down everything on your mind before planning your blocks."
+          ></textarea>
+        </section>
+      </div>
+
+      <div class="column column--right">
+        <section class="card schedule">
+          <div class="section-header">
+            <h2>Schedule</h2>
+            <div class="controls">
+              <button type="button" id="clear-planner" class="secondary">
+                Clear Planner
+              </button>
+              <button type="button" id="print-planner" class="primary">
+                Print
+              </button>
+            </div>
+          </div>
+
+          <table class="schedule-table" aria-label="Daily schedule">
+            <thead>
+              <tr>
+                <th scope="col" class="time-col">Time</th>
+                <th scope="col">:00</th>
+                <th scope="col">:30</th>
+              </tr>
+            </thead>
+            <tbody id="schedule-body"></tbody>
+          </table>
+        </section>
+      </div>
+    </main>
+
+    <footer class="app-footer">
+      <p>
+        Pro tip: Plan your most important work during the hours when you have the
+        most energy.
+      </p>
+    </footer>
+
+    <script src="script.js" defer></script>
+  </body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,194 @@
+(function () {
+  const START_HOUR = 5;
+  const END_HOUR = 23;
+  const STORAGE_KEY = 'timeboxing-planner-state';
+
+  const scheduleBody = document.getElementById('schedule-body');
+  const dateInput = document.getElementById('planner-date');
+  const clearButton = document.getElementById('clear-planner');
+  const printButton = document.getElementById('print-planner');
+
+  buildSchedule();
+
+  const fields = Array.from(document.querySelectorAll('[data-storage-key]'));
+
+  let storageEnabled = true;
+  const state = loadState();
+
+  const initialDate = determineInitialDate(state.lastDate);
+  dateInput.value = initialDate;
+  if (state.lastDate !== initialDate) {
+    state.lastDate = initialDate;
+    saveState();
+  }
+  applyDate(initialDate);
+
+  dateInput.addEventListener('change', handleDateChange);
+  fields.forEach((field) => {
+    field.addEventListener('input', handleFieldInput);
+  });
+
+  clearButton.addEventListener('click', handleClear);
+  printButton.addEventListener('click', () => window.print());
+
+  function buildSchedule() {
+    for (let hour = START_HOUR; hour <= END_HOUR; hour += 1) {
+      const row = document.createElement('tr');
+
+      const timeHeader = document.createElement('th');
+      timeHeader.scope = 'row';
+      timeHeader.className = 'time-label';
+      timeHeader.textContent = formatHourLabel(hour);
+      row.appendChild(timeHeader);
+
+      [0, 30].forEach((minutes) => {
+        const cell = document.createElement('td');
+        const textarea = document.createElement('textarea');
+        textarea.rows = 2;
+        textarea.dataset.storageKey = `slot-${hour}-${minutes === 0 ? '00' : '30'}`;
+        textarea.setAttribute(
+          'aria-label',
+          `${formatHourLabel(hour, true)} ${minutes === 0 ? 'on the hour' : 'half past'}`
+        );
+        cell.appendChild(textarea);
+        row.appendChild(cell);
+      });
+
+      scheduleBody.appendChild(row);
+    }
+  }
+
+  function loadState() {
+    if (!storageEnabled) return createEmptyState();
+    try {
+      const raw = window.localStorage.getItem(STORAGE_KEY);
+      if (!raw) {
+        return createEmptyState();
+      }
+      const parsed = JSON.parse(raw);
+      const lastDate = typeof parsed.lastDate === 'string' ? parsed.lastDate : '';
+      const entries = parsed.entries && typeof parsed.entries === 'object' ? parsed.entries : {};
+      return { lastDate, entries };
+    } catch (error) {
+      storageEnabled = false;
+      console.warn('Local storage is unavailable. Planner data will not persist.', error);
+      return createEmptyState();
+    }
+  }
+
+  function saveState() {
+    if (!storageEnabled) return;
+    try {
+      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    } catch (error) {
+      storageEnabled = false;
+      console.warn('Local storage is unavailable. Planner data will not persist.', error);
+    }
+  }
+
+  function createEmptyState() {
+    return { lastDate: '', entries: {} };
+  }
+
+  function determineInitialDate(lastDate) {
+    if (isValidDateString(lastDate)) {
+      return lastDate;
+    }
+    return formatDate(new Date());
+  }
+
+  function handleDateChange() {
+    const dateValue = getActiveDate();
+    state.lastDate = dateValue;
+    saveState();
+    applyDate(dateValue);
+  }
+
+  function handleFieldInput(event) {
+    const target = event.target;
+    const key = target.dataset.storageKey;
+    if (!key) return;
+
+    const activeDate = getActiveDate();
+    const entry = getOrCreateEntry(activeDate);
+    const value = target.value;
+
+    if (value.trim().length === 0) {
+      delete entry[key];
+      cleanupEntryIfEmpty(activeDate);
+    } else {
+      entry[key] = value;
+    }
+    saveState();
+  }
+
+  function handleClear() {
+    const activeDate = getActiveDate();
+    if (!activeDate) return;
+
+    const hasContent = fields.some((field) => field.value.trim().length > 0);
+    if (!hasContent) return;
+
+    const confirmClear = window.confirm('Clear all planner fields for the selected date?');
+    if (!confirmClear) return;
+
+    fields.forEach((field) => {
+      field.value = '';
+    });
+
+    delete state.entries[activeDate];
+    saveState();
+  }
+
+  function applyDate(dateValue) {
+    const entry = state.entries[dateValue] || {};
+    fields.forEach((field) => {
+      const key = field.dataset.storageKey;
+      field.value = entry[key] || '';
+    });
+  }
+
+  function getActiveDate() {
+    if (dateInput.value && isValidDateString(dateInput.value)) {
+      return dateInput.value;
+    }
+    const today = formatDate(new Date());
+    dateInput.value = today;
+    return today;
+  }
+
+  function getOrCreateEntry(dateValue) {
+    if (!state.entries[dateValue]) {
+      state.entries[dateValue] = {};
+    }
+    return state.entries[dateValue];
+  }
+
+  function cleanupEntryIfEmpty(dateValue) {
+    if (!state.entries[dateValue]) return;
+    const hasValues = Object.keys(state.entries[dateValue]).length > 0;
+    if (!hasValues) {
+      delete state.entries[dateValue];
+    }
+  }
+
+  function isValidDateString(value) {
+    return typeof value === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(value);
+  }
+
+  function formatDate(date) {
+    const year = date.getFullYear();
+    const month = String(date.getMonth() + 1).padStart(2, '0');
+    const day = String(date.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  }
+
+  function formatHourLabel(hour, verbose = false) {
+    const suffix = hour >= 12 ? 'PM' : 'AM';
+    const displayHour = ((hour + 11) % 12) + 1;
+    if (verbose) {
+      return `${displayHour}:00 ${suffix}`;
+    }
+    return `${displayHour} ${suffix}`;
+  }
+})();

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,257 @@
+:root {
+  color-scheme: light;
+  --background: #f8f7ff;
+  --card-background: #ffffff;
+  --primary: #4a5fdc;
+  --primary-dark: #3646a6;
+  --secondary: #e4e7ff;
+  --border: #d9dcf2;
+  --text: #1f2430;
+  --muted: #5c6473;
+  --shadow: 0 12px 24px rgba(31, 36, 48, 0.08);
+  font-family: "Inter", "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: linear-gradient(135deg, #f1f0ff 0%, #f9fbff 100%);
+  color: var(--text);
+}
+.noscript-warning {
+  margin: 0 clamp(1.5rem, 4vw, 3.5rem);
+  background: #fff1f0;
+  color: #8a2525;
+  border: 1px solid #f5c2c0;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  font-size: 0.95rem;
+}
+
+
+.app-header {
+  display: flex;
+  align-items: flex-end;
+  justify-content: space-between;
+  padding: 2.5rem clamp(1.5rem, 4vw, 3.5rem) 1.5rem;
+  gap: 1rem;
+}
+
+.app-header h1 {
+  margin: 0;
+  font-size: clamp(1.75rem, 3vw, 2.5rem);
+}
+
+.tagline {
+  margin: 0.25rem 0 0;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.date-picker {
+  display: grid;
+  gap: 0.35rem;
+  font-size: 0.9rem;
+}
+
+.date-picker label {
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.date-picker input[type="date"] {
+  padding: 0.6rem 0.75rem;
+  border: 1px solid var(--border);
+  border-radius: 0.5rem;
+  background: var(--card-background);
+  font: inherit;
+  color: inherit;
+}
+
+.planner {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: clamp(1.25rem, 3vw, 2rem);
+  padding: 0 clamp(1.5rem, 4vw, 3.5rem) 3rem;
+}
+
+.column {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.25rem, 3vw, 2rem);
+}
+
+.card {
+  background: var(--card-background);
+  border-radius: 1.25rem;
+  padding: clamp(1.25rem, 2.5vw, 2rem);
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.card h2 {
+  margin: 0;
+  font-size: 1.1rem;
+  letter-spacing: 0.015em;
+  text-transform: uppercase;
+  color: var(--primary-dark);
+}
+
+.section-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.helper-text {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.9rem;
+}
+
+.priority-list {
+  margin: 0;
+  padding-left: 1.25rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.priority-list textarea {
+  min-height: 3.6rem;
+}
+
+textarea {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: 0.75rem;
+  padding: 0.75rem 0.85rem;
+  font: inherit;
+  resize: vertical;
+  background: #fcfcff;
+  color: inherit;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+textarea:focus,
+input:focus {
+  outline: none;
+  border-color: var(--primary);
+  box-shadow: 0 0 0 3px rgba(74, 95, 220, 0.18);
+}
+
+textarea::placeholder {
+  color: #9aa0b5;
+}
+
+.controls {
+  display: flex;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+button {
+  font: inherit;
+  cursor: pointer;
+  border-radius: 999px;
+  padding: 0.45rem 1.1rem;
+  border: none;
+  transition: transform 0.15s ease, box-shadow 0.15s ease, background 0.15s ease;
+}
+
+button.primary {
+  background: var(--primary);
+  color: white;
+  box-shadow: 0 10px 18px rgba(74, 95, 220, 0.22);
+}
+
+button.primary:hover {
+  background: var(--primary-dark);
+  transform: translateY(-1px);
+}
+
+button.secondary {
+  background: var(--secondary);
+  color: var(--primary-dark);
+}
+
+button.secondary:hover {
+  background: #d5dafd;
+  transform: translateY(-1px);
+}
+
+.schedule-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  font-size: 0.95rem;
+}
+
+.schedule-table thead th {
+  text-align: center;
+  padding-bottom: 0.75rem;
+  color: var(--muted);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.schedule-table .time-col {
+  width: 4.5rem;
+  text-align: left;
+  padding-left: 0.25rem;
+}
+
+.schedule-table tbody tr {
+  border-top: 1px solid var(--border);
+}
+
+.schedule-table tbody tr:first-child {
+  border-top: none;
+}
+
+.schedule-table th,
+.schedule-table td {
+  padding: 0.35rem 0.4rem;
+  vertical-align: top;
+}
+
+.schedule-table td textarea {
+  min-height: 3.5rem;
+  resize: vertical;
+}
+
+.time-label {
+  font-weight: 600;
+  color: var(--muted);
+  font-size: 0.95rem;
+}
+
+.app-footer {
+  padding: 1.5rem clamp(1.5rem, 4vw, 3.5rem) 3rem;
+  color: var(--muted);
+  text-align: center;
+  font-size: 0.9rem;
+}
+
+@media (max-width: 720px) {
+  .app-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  .controls {
+    width: 100%;
+    justify-content: flex-start;
+  }
+}


### PR DESCRIPTION
## Summary
- add a single-page time boxing planner with top priorities, brain dump, and schedule layout
- implement styling, responsive layout, and a noscript warning for the planner
- add JavaScript that builds schedule slots, saves data per day in local storage, and supports clearing/printing
- document features and usage in the README

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68c96fbdd498832d96b86b6c4b63b47b